### PR TITLE
chore: sync github-guard hooks to reconciled version

### DIFF
--- a/.githooks/pre-commit.d/github-protect-main.sh
+++ b/.githooks/pre-commit.d/github-protect-main.sh
@@ -58,12 +58,18 @@ fi
 # containing `"` or `\` would read back double-escaped and never equal the
 # `jq -c`-encoded `desired`, re-applying protection on every commit. `tojson`
 # output is single-line, so line-reading each field is safe. Empty when unprotected.
-{ IFS= read -r has_reviews; IFS= read -r has_admins; IFS= read -r current; } < <(
+{ IFS= read -r has_reviews; IFS= read -r has_admins; IFS= read -r current; IFS= read -r review_count; } < <(
   gh api "repos/$slug/branches/$branch/protection" --jq \
     '(.required_pull_request_reviews != null),
      (.enforce_admins.enabled // false),
-     ((.required_status_checks.checks // []) | map({context: .context}) | unique | tojson)' 2>/dev/null)
+     ((.required_status_checks.checks // []) | map({context: .context}) | unique | tojson),
+     (.required_pull_request_reviews.required_approving_review_count // 0)' 2>/dev/null)
 [ -n "$current" ] || current='[]'
+# Preserve any already-configured approval count instead of hardcoding 0: re-applying
+# protection must never silently DOWNGRADE a team's "require N reviews" back to 0.
+# Default 0 (require a PR, no approvals) for the solo case / a fresh unprotected branch.
+# Sanitize to digits so only a number can reach the JSON payload below.
+case "$review_count" in '' | *[!0-9]*) review_count=0 ;; esac
 
 # Checks to require: be strictly ADDITIVE — union what we just discovered with
 # what's already required, never a bare replace. A discovery that's non-empty but
@@ -102,7 +108,7 @@ payload=$(cat <<JSON
 {
   "required_status_checks": $rsc,
   "enforce_admins": true,
-  "required_pull_request_reviews": { "required_approving_review_count": 0, "dismiss_stale_reviews": false, "require_code_owner_reviews": false },
+  "required_pull_request_reviews": { "required_approving_review_count": $review_count, "dismiss_stale_reviews": false, "require_code_owner_reviews": false },
   "restrictions": null,
   "required_linear_history": true,
   "allow_force_pushes": false,

--- a/.githooks/pre-commit.d/rust-deps-pinned.sh
+++ b/.githooks/pre-commit.d/rust-deps-pinned.sh
@@ -125,8 +125,21 @@ if [ "$lock_tracked" = 1 ] && [ ! -f Cargo.lock ]; then
   echo "       Restore it: git checkout -- Cargo.lock   (or: cargo generate-lockfile)" >&2
   fail=1
 elif [ -f Cargo.lock ]; then
-  pkg=$(awk -F'"' '/^name[[:space:]]*=/{print $2; exit}' Cargo.toml)
-  ver=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' Cargo.toml)
+  # Read name/version ONLY from the [package] section. A workspace root, or a
+  # manifest carrying [[bin]]/[lib]/[workspace.dependencies] sections, has other
+  # `name =`/`version =` keys; a first-match scan would grab the wrong one (or, in
+  # a virtual workspace root with no [package], nothing meaningful) and either
+  # mis-compare or silently no-op. Section-scoping keeps the drift check honest;
+  # a manifest with no [package] (virtual workspace root) correctly yields empty
+  # and the guarded block below skips.
+  pkg=$(awk -F'"' '
+    /^[[:space:]]*\[/ { inpkg = ($0 ~ /^[[:space:]]*\[package\]/) }
+    inpkg && /^[[:space:]]*name[[:space:]]*=/ { print $2; exit }
+  ' Cargo.toml)
+  ver=$(awk -F'"' '
+    /^[[:space:]]*\[/ { inpkg = ($0 ~ /^[[:space:]]*\[package\]/) }
+    inpkg && /^[[:space:]]*version[[:space:]]*=/ { print $2; exit }
+  ' Cargo.toml)
   if [ -n "$pkg" ] && [ -n "$ver" ]; then
     lockver=$(awk -v p="$pkg" '
       $0 == "name = \"" p "\"" { hit=1; next }

--- a/.githooks/pre-push.d/git-changelog.sh
+++ b/.githooks/pre-push.d/git-changelog.sh
@@ -13,10 +13,64 @@
 # Conventions: the README changelog section is a heading matching
 # changelog/release notes/recent changes/releases/history; version entries
 # inside it are deeper (e.g. `### v0.2.0`) sub-headings. Bypass: git push --no-verify.
+#
+# Also usable as a CLI: `git-changelog.sh notes vX.Y.Z` prints that version's
+# release notes from CHANGELOG.md. A release pipeline can call this, so the
+# changelog this guard enforces is the single source of truth for release bodies.
 set -u
 dir=$(cd "$(dirname "$0")/.." && pwd)   # .githooks/
 # shellcheck source=../lib/common.sh
 . "$dir/lib/common.sh"
+
+# --- changelog extraction (shared by the hook below and a release pipeline) ---
+# Print CHANGELOG.md's body for a version (no heading) — from its "## vX.Y.Z"
+# heading up to the next "## v" heading, with leading blank lines trimmed.
+# Reads the changelog on stdin.
+changelog_section() {  # $1 = version, no leading v
+  awk -v ver="$1" '
+    /^##[[:space:]]+v/ {
+      s=$0; sub(/^##[[:space:]]+v/, "", s); split(s, a, /[[:space:]]/); v=a[1]
+      if (insec) exit
+      if (v == ver) { insec=1; next }
+    }
+    insec {
+      if (!started && $0 ~ /^[[:space:]]*$/) next
+      started=1; print
+    }
+  '
+}
+
+# Print the version of the next-older release (the "## v" heading after $1),
+# for the "Full Changelog" compare link. Empty for the first release.
+changelog_prev_version() {  # $1 = version, no leading v
+  awk -v ver="$1" '
+    /^##[[:space:]]+v/ {
+      s=$0; sub(/^##[[:space:]]+v/, "", s); split(s, a, /[[:space:]]/); v=a[1]
+      if (found) { print v; exit }
+      if (v == ver) found=1
+    }
+  '
+}
+
+# Subcommand `notes <version>`: emit GitHub release notes for a version from the
+# SAME CHANGELOG.md this guard enforces, so the release body can't drift from the
+# changelog. Fails loudly if the section is missing (the guard would have blocked
+# the tag anyway).  Usage: git-changelog.sh notes v0.4.0
+if [ "${1:-}" = "notes" ]; then
+  ver=${2#v}
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "git-changelog: not a git repo" >&2; exit 1; }
+  cl="$root/CHANGELOG.md"
+  [ -f "$cl" ] || { echo "git-changelog: no CHANGELOG.md" >&2; exit 1; }
+  body=$(changelog_section "$ver" < "$cl")
+  [ -n "$body" ] || { echo "git-changelog: no '## v$ver' section in CHANGELOG.md" >&2; exit 1; }
+  printf "## What's Changed\n\n%s\n" "$body"
+  prev=$(changelog_prev_version "$ver" < "$cl")
+  slug=$(gg_repo_slug)
+  if [ -n "$prev" ] && [ -n "$slug" ]; then
+    printf '\n**Full Changelog**: https://github.com/%s/compare/v%s...v%s\n' "$slug" "$prev" "$ver"
+  fi
+  exit 0
+fi
 
 # Self-gate: repos without a changelog convention are unaffected.
 gg_has_changelog || exit 0


### PR DESCRIPTION
Re-syncs `.githooks/` to the reconciled github-guard (adds the `git-changelog notes` subcommand + the review-count / `[package]` guard fixes). Hooks-only change.